### PR TITLE
Move SCR calls to initWrite() and endWrite() in the openPMD plugin

### DIFF
--- a/include/picongpu/plugins/openPMD/openPMDWriter.hpp
+++ b/include/picongpu/plugins/openPMD/openPMDWriter.hpp
@@ -137,7 +137,6 @@ namespace picongpu
                 // avoid deadlock between not finished pmacc tasks and mpi calls in
                 // openPMD
                 __getTransactionEvent().waitForFinished();
-                //SCR_Start_output(fullName, SCR_FLAG_OUTPUT);
                 openPMDSeries = std::make_unique<::openPMD::Series>(
                     fullName,
                     at,
@@ -178,7 +177,6 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
                 log<picLog::INPUT_OUTPUT>("openPMD: close file: %1%") % fileName;
                 openPMDSeries.reset();
                 MPI_Barrier(this->communicator);
-                //SCR_Complete_output(1);
                 log<picLog::INPUT_OUTPUT>("openPMD: successfully closed file: %1%") % fileName;
             }
             else
@@ -900,10 +898,13 @@ make sure that environment variable OPENPMD_BP_BACKEND is not set to ADIOS1.
             void endWrite()
             {
                 mThreadParams.fieldBuffer.resize(0);
+                //SCR_Complete_output(1);
             }
 
             void initWrite()
             {
+                //SCR_Start_output(fullName, SCR_FLAG_OUTPUT);
+
                 // fieldBuffer will only be resized if needed
                 // in some openPMD backends, it's more efficient to let the backend handle buffer creation
                 // (span-based RecordComponent::storeChunk() API)


### PR DESCRIPTION
Hey Adam,
this PR moves the (currently commented) `SCR_start_output` and `SCR_complete_output` calls to the `initWrite` and `endWrite` functions in the openPMDWriter. 
This means that they will be called for every checkpoint which I assume is intended? Note that the `Series` object will stay open during the entire simulation, which is necessary e.g. for streaming workflows. So, without this PR both functions would be called exactly once during a simulation.

What would happen if these functions are called, but no SCR output is written in-between? This might happen if we write normal (non-checkpoint) output or use any other backend of ADIOS2/openPMD, such as HDF5 or Streaming.

(Note: I'm on holidays for the coming two weeks)